### PR TITLE
change to arguments

### DIFF
--- a/src/ros_mono.cc
+++ b/src/ros_mono.cc
@@ -49,14 +49,14 @@ int main(int argc, char **argv)
     ros::init(argc, argv, "Mono");
     ros::start();
 
-    if(argc != 2)
+    if(argc != 3)
     {
-        cerr << endl << "Usage: rosrun ORB_SLAM2 Mono path_to_vocabulary path_to_settings" << endl;        
+        cerr << endl << "Usage: rosrun ORB_SLAM2 Mono path_to_settings" << endl;
         ros::shutdown();
         return 1;
     }    
-
-    string voc_dir = "/home/zl/catkin_ws/src/parkingEnvSensing/Vocabulary/ORBvoc.bin";
+    
+    string voc_dir = argv[2];
     string config_dir = argv[1];
     
     // Create SLAM system. It initializes all system threads and gets ready to process frames.

--- a/src/ros_stereo.cc
+++ b/src/ros_stereo.cc
@@ -58,14 +58,14 @@ int main(int argc, char **argv)
     ros::start();
     ros::NodeHandle nh;
     
-    if(argc != 2)
+    if(argc != 3)
     {
         cerr << endl << "Usage: rosrun ORB_SLAM2 Stereo path_to_settings" << endl;
         ros::shutdown();
         return 1;
     }    
     
-    string voc_dir = "/home/zl/catkin_ws/src/parkingEnvSensing/Vocabulary/ORBvoc.txt";
+    string voc_dir = argv[2];
     string config_dir = argv[1];
     
     // Create SLAM system. It initializes all system threads and gets ready to process frames.


### PR DESCRIPTION
It was modified for arguments, to correct the error of the vocabulary file that was not found due to the directory of the same one does not exist, since it was set manually, this correction allows the passage of arguments by launch file.